### PR TITLE
Fix StringBuilder deserialization in 1.x.

### DIFF
--- a/src/main/java/de/ruedigermoeller/serialization/serializers/FSTStringBuilderSerializer.java
+++ b/src/main/java/de/ruedigermoeller/serialization/serializers/FSTStringBuilderSerializer.java
@@ -35,7 +35,7 @@ import java.io.IOException;
 public class FSTStringBuilderSerializer extends FSTStringBufferSerializer {
     @Override
     public Object instantiate(Class objectClass, FSTObjectInput in, FSTClazzInfo serializationInfo, FSTClazzInfo.FSTFieldInfo referencee, int streamPositioin) throws IOException, ClassNotFoundException, InstantiationException, IllegalAccessException {
-        String s = in.readUTF();
+        String s = in.readStringUTF();
         StringBuilder stringBuilder = new StringBuilder(s);
         in.registerObject(stringBuilder, streamPositioin,serializationInfo, referencee);
         return stringBuilder;


### PR DESCRIPTION
This is a patch for 1.x line.

In 1.x, the StringBuilder deserialization is broken (we don't have any problem with 2.x at the moment). It's a simple oversight and I fixed it by making the StringBuilder code in line with the StringBuffer one.

It's definitely worth a test but I'm not familiar with your test framework and I have compilation issues in the TestRunner class.

See http://share.openwide.fr/share/zone/gsmet/3793121894 for a simple Maven project reproducing the issue. You should have the following stacktrace before the fix:

```
java.io.IOException: java.lang.RuntimeException: java.io.EOFException
    at de.ruedigermoeller.serialization.FSTObjectInput.readObject(FSTObjectInput.java:168)
    at fr.openwide.fast.test.stringbuilder.TestStringBuilderSerialization.serializeDeserialize(TestStringBuilderSerialization.java:34)
    at fr.openwide.fast.test.stringbuilder.TestStringBuilderSerialization.test(TestStringBuilderSerialization.java:18)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:606)
    at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47)
    at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
    at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:44)
    at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
    at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
    at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70)
    at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
    at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
    at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
    at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
    at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
    at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
    at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
    at org.eclipse.jdt.internal.junit4.runner.JUnit4TestReference.run(JUnit4TestReference.java:50)
    at org.eclipse.jdt.internal.junit.runner.TestExecution.run(TestExecution.java:38)
    at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:459)
    at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:675)
    at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.run(RemoteTestRunner.java:382)
    at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.main(RemoteTestRunner.java:192)
Caused by: java.lang.RuntimeException: java.io.EOFException
    at de.ruedigermoeller.serialization.util.FSTUtil.rethrow(FSTUtil.java:119)
    at de.ruedigermoeller.serialization.FSTObjectInput.readObjectWithHeader(FSTObjectInput.java:265)
    at de.ruedigermoeller.serialization.FSTObjectInput.readObjectInternal(FSTObjectInput.java:230)
    at de.ruedigermoeller.serialization.FSTObjectInput.readObject(FSTObjectInput.java:210)
    at de.ruedigermoeller.serialization.FSTObjectInput.readObject(FSTObjectInput.java:165)
    ... 25 more
Caused by: java.io.EOFException
    at java.io.DataInputStream.readFully(DataInputStream.java:197)
    at java.io.DataInputStream.readUTF(DataInputStream.java:609)
    at java.io.DataInputStream.readUTF(DataInputStream.java:564)
    at de.ruedigermoeller.serialization.serializers.FSTStringBuilderSerializer.instantiate(FSTStringBuilderSerializer.java:38)
    at de.ruedigermoeller.serialization.FSTObjectInput.instantiateAndReadWithSer(FSTObjectInput.java:361)
    at de.ruedigermoeller.serialization.FSTObjectInput.readObjectWithHeader(FSTObjectInput.java:260)
    ... 28 more
```

and a success after.

HTH.
