### PR TITLE
Android unsafe fix

### DIFF
--- a/src/main/java/org/nustaq/serialization/FSTClazzInfo.java
+++ b/src/main/java/org/nustaq/serialization/FSTClazzInfo.java
@@ -718,21 +718,21 @@ public final class FSTClazzInfo {
         }
 
         public final int getByteValue(Object obj) throws IllegalAccessException {
-            if (memOffset >= 0) {
+            if (!FSTConfiguration.isAndroid && memOffset >= 0) {
                 return FSTUtil.unFlaggedUnsafe.getByte(obj, memOffset);
             }
             return field.getByte(obj);
         }
 
         public final int getCharValue(Object obj) throws IllegalAccessException {
-            if (memOffset >= 0) {
+            if (!FSTConfiguration.isAndroid && memOffset >= 0) {
                 return FSTUtil.unFlaggedUnsafe.getChar(obj, memOffset);
             }
             return field.getChar(obj);
         }
 
         public final int getShortValue(Object obj) throws IllegalAccessException {
-            if (memOffset >= 0) {
+            if (!FSTConfiguration.isAndroid && memOffset >= 0) {
                 return FSTUtil.unFlaggedUnsafe.getShort(obj, memOffset);
             }
             return field.getShort(obj);
@@ -748,7 +748,7 @@ public final class FSTClazzInfo {
         }
 
         public final boolean getBooleanValue(Object obj) throws IllegalAccessException {
-            if (memOffset >= 0) {
+            if (!FSTConfiguration.isAndroid && memOffset >= 0) {
                 return FSTUtil.unFlaggedUnsafe.getBoolean(obj, memOffset);
             }
             return field.getBoolean(obj);
@@ -770,14 +770,14 @@ public final class FSTClazzInfo {
         }
 
         public final float getFloatValue(Object obj) throws IllegalAccessException {
-            if (memOffset >= 0) {
+            if (!FSTConfiguration.isAndroid && memOffset >= 0) {
                 return FSTUtil.unFlaggedUnsafe.getFloat(obj, memOffset);
             }
             return field.getFloat(obj);
         }
 
         public final void setCharValue(Object newObj, char c) throws IllegalAccessException {
-            if (memOffset >= 0) {
+            if (!FSTConfiguration.isAndroid && memOffset >= 0) {
                 FSTUtil.unFlaggedUnsafe.putChar(newObj, memOffset, c);
                 return;
             }
@@ -785,7 +785,7 @@ public final class FSTClazzInfo {
         }
 
         public final void setShortValue(Object newObj, short i1) throws IllegalAccessException {
-            if (memOffset >= 0) {
+            if (!FSTConfiguration.isAndroid && memOffset >= 0) {
                 FSTUtil.unFlaggedUnsafe.putShort(newObj, memOffset, i1);
                 return;
             }
@@ -801,7 +801,7 @@ public final class FSTClazzInfo {
         }
 
         public final void setFloatValue(Object newObj, float l) throws IllegalAccessException {
-            if (memOffset >= 0) {
+            if (!FSTConfiguration.isAndroid && memOffset >= 0) {
                 FSTUtil.unFlaggedUnsafe.putFloat(newObj, memOffset, l);
                 return;
             }
@@ -809,7 +809,7 @@ public final class FSTClazzInfo {
         }
 
         public final void setDoubleValue(Object newObj, double l) throws IllegalAccessException {
-            if (memOffset >= 0) {
+            if (!FSTConfiguration.isAndroid && memOffset >= 0) {
                 FSTUtil.unFlaggedUnsafe.putDouble(newObj, memOffset, l);
                 return;
             }
@@ -832,7 +832,7 @@ public final class FSTClazzInfo {
         }
 
         public final double getDoubleValue(Object obj) throws IllegalAccessException {
-            if (memOffset >= 0) {
+            if (!FSTConfiguration.isAndroid && memOffset >= 0) {
                 return FSTUtil.unFlaggedUnsafe.getDouble(obj, memOffset);
             }
             return field.getDouble(obj);
@@ -854,7 +854,7 @@ public final class FSTClazzInfo {
         }
 
         public final void setBooleanValue(Object newObj, boolean i1) throws IllegalAccessException {
-            if (memOffset >= 0) {
+            if (!FSTConfiguration.isAndroid && memOffset >= 0) {
                 FSTUtil.unFlaggedUnsafe.putBoolean(newObj, memOffset, i1);
                 return;
             }
@@ -862,7 +862,7 @@ public final class FSTClazzInfo {
         }
 
         public final void setByteValue(Object newObj, byte b) throws IllegalAccessException {
-            if (memOffset >= 0) {
+            if (!FSTConfiguration.isAndroid && memOffset >= 0) {
                 FSTUtil.unFlaggedUnsafe.putByte(newObj, memOffset, b);
                 return;
             }

--- a/src/main/java/org/nustaq/serialization/FSTConfiguration.java
+++ b/src/main/java/org/nustaq/serialization/FSTConfiguration.java
@@ -110,6 +110,8 @@ public class FSTConfiguration {
     private HashMap<String, String> minbinNamesReverse = new HashMap<>();
     private boolean crossPlatform = false; // if true do not support writeObject/readObject etc.
 
+    public static final boolean isAndroid = System.getProperty("java.runtime.name", "no").toLowerCase().contains("android");
+
     // end cross platform stuff only
     /////////////////////////////////////
 
@@ -223,15 +225,11 @@ public class FSTConfiguration {
      * @return
      */
     public static FSTConfiguration createDefaultConfiguration() {
-        if (isAndroid()) {
+        if (isAndroid) {
             return createAndroidDefaultConfiguration();
         }
         FSTConfiguration conf = new FSTConfiguration();
         return initDefaultFstConfigurationInternal(conf);
-    }
-
-    public static boolean isAndroid() {
-        return System.getProperty("java.runtime.name","no").toLowerCase().indexOf("android") >= 0;
     }
 
     protected static FSTConfiguration initDefaultFstConfigurationInternal(FSTConfiguration conf) {


### PR DESCRIPTION
Fix for #53 
Actually, Unsafe is partially supported on Android.
Kryo has chosen the way to remove it completely: https://github.com/EsotericSoftware/kryo/blob/135a31bfd4c40cd7e059ca2a5269c35a97c0b08d/src/com/esotericsoftware/kryo/util/UnsafeUtil.java#L83
But I think that it is better to use existing methods and don't use nonexistent unsafe methods.
So I added some checks before nonexistent methods.
If you consider this pr reasonable, please publish new release to maven central.

The way to reproduce issue: just try on android to serialize object with field of type boolean or float.