### PR TITLE
Eliminate a fixed-size stack.

### DIFF
--- a/src/main/java/org/nustaq/serialization/FSTObjectInput.java
+++ b/src/main/java/org/nustaq/serialization/FSTObjectInput.java
@@ -1245,17 +1245,15 @@ public class FSTObjectInput implements ObjectInput {
     static class MyObjectStream extends ObjectInputStream {
 
         ObjectInputStream wrapped;
-        ObjectInputStream wrappedArr[] = new ObjectInputStream[30]; // if this is not sufficient use another lib ..
-        int idx = 0;
+        ArrayDeque<ObjectInputStream> wrappedStack = new ArrayDeque<ObjectInputStream>();
 
         public void push( ObjectInputStream in ) {
-            wrappedArr[idx++] = in;
+            wrappedStack.push(in);
             wrapped = in;
         }
 
         public void pop() {
-            idx--;
-            wrapped = wrappedArr[idx];
+            wrapped = wrappedStack.pop();
         }
 
         MyObjectStream() throws IOException, SecurityException {


### PR DESCRIPTION
Thanks very much for releasing FST.  It has solved a nasty performance problem for me.

However, having a fixed-size stack in the deserializer doesn't work for my application, which involves serializing arbitrarily-deep trees.  The fix is quite straightforward, and I hope you won't mind merging it.
