### PR TITLE
Array requested larger than VM allowed size

### DIFF
--- a/src/main/java/org/nustaq/serialization/coders/FSTBytezDecoder.java
+++ b/src/main/java/org/nustaq/serialization/coders/FSTBytezDecoder.java
@@ -15,14 +15,11 @@
  */
 package org.nustaq.serialization.coders;
 
-import org.nustaq.offheap.bytez.BasicBytez;
-import org.nustaq.offheap.bytez.onheap.HeapBytez;
+import java.io.*;
+import org.nustaq.offheap.bytez.*;
+import org.nustaq.offheap.bytez.onheap.*;
 import org.nustaq.serialization.*;
-import org.nustaq.serialization.util.FSTUtil;
-
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
+import org.nustaq.serialization.util.*;
 
 /**
  * Created by ruedi on 09.11.2014.
@@ -76,7 +73,7 @@ public class FSTBytezDecoder  implements FSTDecoder {
 
     protected int readNextInputChunk(int bytes) {
         try {
-            int toRead = Math.max(Integer.MAX_VALUE, bytes);
+            int toRead = Integer.MAX_VALUE - 5;
             if ( inputStream instanceof ByteArrayInputStream ) {
                 toRead = Math.min(((ByteArrayInputStream) inputStream).available(),toRead);
             }


### PR DESCRIPTION
This fixes the common exception thrown when using the FastBinary configuration of "Requested array is larger than VM allowed size"

Java uses the `int` to index arrays, and you will run into this issue quite often if you're trying to use the `Math.max` comparison between `Integer.MAX_VALUE` and your `byte` variable.

Most JVMs use between 3-4 for index related head space, so a maximum safe size is actually going to be about `Integer.MAX_VALUE - 5` for most platforms. (Some platforms might behave on `Integer.MAX_VALUE - 4`)

However, allocating an array even this large is not recommended, but in the effort to maintain the code per original, I didn't through it out completely. An array several gigs in size to read a small object graph, is highly unnecessary. Even in the event of larger graphs, I think you could get away with resizing the array based on the circumstances.

Realistically, an array of maybe 10,000 would be perfectly fine for more than 90% of cases...