### PR TITLE
When a decoding error occurs, the whole byte array to be deserialized…

### DIFF
--- a/src/main/java/org/nustaq/serialization/FSTConfiguration.java
+++ b/src/main/java/org/nustaq/serialization/FSTConfiguration.java
@@ -1105,7 +1105,8 @@ public class FSTConfiguration {
         try {
             return getObjectInput(b).readObject();
         } catch (Exception e) {
-            System.out.println("unable to decode:" +new String(b,0) );
+            System.out.println("unable to decode:" + new String(b,0).
+                substring(0, Math.min(b.length, 500)));
             try {
                 getObjectInput(b).readObject();
             } catch (Exception e1) {


### PR DESCRIPTION
… is printed to the standard output. This can be quite disruptive, especially when dealing with large serialized objects. Truncate the undecodable array to its first 500 characters when printing it out.