### PR TITLE
Unmodifiable serializers for JSON config only

### DIFF
--- a/src/main/java/org/nustaq/serialization/FSTConfiguration.java
+++ b/src/main/java/org/nustaq/serialization/FSTConfiguration.java
@@ -291,6 +291,13 @@ public class FSTConfiguration {
 
     private static FSTConfiguration constructJsonConf(boolean prettyPrint, boolean shareReferences, ConcurrentHashMap<FieldKey, FSTClazzInfo.FSTFieldInfo> shared) {
         final FSTConfiguration conf = createMinBinConfiguration(shared);
+
+        FSTSerializerRegistry reg = conf.serializationInfoRegistry.getSerializerRegistry();
+        reg.putSerializer(FSTUnmodifiableCollectionSerializer.UNMODIFIABLE_COLLECTION_CLASS, new FSTUnmodifiableCollectionSerializer(), true);
+        reg.putSerializer(FSTUnmodifiableCollectionSerializer.UNMODIFIABLE_LIST_CLASS, new FSTUnmodifiableCollectionSerializer(), true);
+        reg.putSerializer(FSTUnmodifiableCollectionSerializer.UNMODIFIABLE_SET_CLASS, new FSTUnmodifiableCollectionSerializer(), true);
+        reg.putSerializer(FSTUnmodifiableMapSerializer.UNMODIFIABLE_MAP_CLASS, new FSTUnmodifiableMapSerializer(), true);
+
         conf.type = prettyPrint ? ConfType.JSONPRETTY : ConfType.JSON;
         JsonFactory fac;
         if ( prettyPrint ) {
@@ -472,11 +479,6 @@ public class FSTConfiguration {
 
         // serializers for classes failing in fst JDK emulation (e.g. Android<=>JDK)
         reg.putSerializer(BigInteger.class, new FSTBigIntegerSerializer(), true);
-
-        reg.putSerializer(FSTUnmodifiableCollectionSerializer.UNMODIFIABLE_COLLECTION_CLASS, new FSTUnmodifiableCollectionSerializer(), true);
-        reg.putSerializer(FSTUnmodifiableCollectionSerializer.UNMODIFIABLE_LIST_CLASS, new FSTUnmodifiableCollectionSerializer(), true);
-        reg.putSerializer(FSTUnmodifiableCollectionSerializer.UNMODIFIABLE_SET_CLASS, new FSTUnmodifiableCollectionSerializer(), true);
-        reg.putSerializer(FSTUnmodifiableMapSerializer.UNMODIFIABLE_MAP_CLASS, new FSTUnmodifiableMapSerializer(), true);
 
         return conf;
     }

--- a/src/main/java/org/nustaq/serialization/serializers/FSTUnmodifiableCollectionSerializer.java
+++ b/src/main/java/org/nustaq/serialization/serializers/FSTUnmodifiableCollectionSerializer.java
@@ -22,11 +22,12 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
 /**
+ * For JSON only, see {@link <a href="https://github.com/RuedigerMoeller/fast-serialization/issues/114">Unable to deserialize unmodifiable collections from JSON</a>}.
+ *
  * @author Jakub Kubrynski
  */
 public class FSTUnmodifiableCollectionSerializer extends FSTCollectionSerializer {
@@ -51,7 +52,7 @@ public class FSTUnmodifiableCollectionSerializer extends FSTCollectionSerializer
                 return Collections.unmodifiableList(res);
             }
             if (UNMODIFIABLE_SET_CLASS.isAssignableFrom(objectClass)) {
-                Set res = new LinkedHashSet(len);
+                Set res = new HashSet(len);
                 fillArray(in, serializationInfo, referencee, streamPosition, res, len);
                 return Collections.unmodifiableSet(res);
             }

--- a/src/main/java/org/nustaq/serialization/serializers/FSTUnmodifiableMapSerializer.java
+++ b/src/main/java/org/nustaq/serialization/serializers/FSTUnmodifiableMapSerializer.java
@@ -19,10 +19,11 @@ import org.nustaq.serialization.util.FSTUtil;
 
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
+ * For JSON only, see {@link <a href="https://github.com/RuedigerMoeller/fast-serialization/issues/114">Unable to deserialize unmodifiable collections from JSON</a>}.
+ *
  * @author Jakub Kubrynski
  */
 public class FSTUnmodifiableMapSerializer extends FSTMapSerializer {
@@ -39,7 +40,7 @@ public class FSTUnmodifiableMapSerializer extends FSTMapSerializer {
         try {
             int len = in.readInt();
             if (UNMODIFIABLE_MAP_CLASS.isAssignableFrom(objectClass)) {
-                Map res = new LinkedHashMap(len);
+                Map res = new HashMap(len);
                 in.registerObject(res, streamPosition, serializationInfo, referencee);
                 for (int i = 0; i < len; i++) {
                     Object key = in.readObjectInternal(null);

--- a/src/test/ser/serializers/FSTUnmodifiableMapSerializerTest.java
+++ b/src/test/ser/serializers/FSTUnmodifiableMapSerializerTest.java
@@ -18,10 +18,10 @@ import org.nustaq.serialization.FSTConfiguration;
 import org.nustaq.serialization.serializers.FSTUnmodifiableMapSerializer;
 
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Jakub Kubrynski
@@ -29,31 +29,22 @@ import static org.junit.Assert.*;
 @SuppressWarnings("unchecked")
 public class FSTUnmodifiableMapSerializerTest {
 
-    static final String TEST_VALUE_1 = "TestValue1";
-    static final String TEST_KEY_1 = "TestKey1";
-    static final String TEST_VALUE_2 = "TestValue2";
-    static final String TEST_KEY_2 = "TestKey2";
-    static final String TEST_VALUE_3 = "TestValue3";
-    static final String TEST_KEY_3 = "TestKey3";
+    static final String TEST_VALUE = "TestValue";
+    static final String TEST_KEY = "TestKey";
 
     @Test
-    public void shouldSerializeUnmodifiableMap() throws Exception {
+    public void shouldSerializeUnmodifiableMap() throws ClassNotFoundException {
         //given
-        Map<String, String> tmp = new LinkedHashMap<>();
-        tmp.put(TEST_KEY_1, TEST_VALUE_1);
-        tmp.put(TEST_KEY_2, TEST_VALUE_2);
-        tmp.put(TEST_KEY_3, TEST_VALUE_3);
-        Map<String, String> map = Collections.unmodifiableMap(tmp);
-
-        FSTConfiguration configuration = FSTConfiguration.createJsonNoRefConfiguration();
+        Map<String, String> map = Collections.unmodifiableMap(Collections.singletonMap(TEST_KEY, TEST_VALUE));
+        FSTConfiguration conf = FSTConfiguration.createJsonNoRefConfiguration();
         //when
-        byte[] bytes = configuration.asByteArray((map));
-        map = (Map<String, String>) configuration.asObject(bytes);
+        byte[] bytes = conf.asByteArray((map));
+        map = (Map<String, String>) conf.asObject(bytes);
         //then
         assertTrue(FSTUnmodifiableMapSerializer.UNMODIFIABLE_MAP_CLASS.isAssignableFrom(map.getClass()));
-        assertEquals(3, map.size());
-
-        assertArrayEquals(new String[]{TEST_KEY_1, TEST_KEY_2, TEST_KEY_3}, map.keySet().toArray(new String[map.keySet().size()]));
-        assertArrayEquals(new String[]{TEST_VALUE_1, TEST_VALUE_2, TEST_VALUE_3}, map.values().toArray(new String[map.values().size()]));
+        assertEquals(1, map.size());
+        assertTrue(map.containsKey(TEST_KEY));
+        assertTrue(map.containsValue(TEST_VALUE));
     }
+
 }


### PR DESCRIPTION
Motivation:

Move unmodifiable serializers to JSON configs as they are not required for default configuration

Modifications:

Moved serializer configuration to constructJsonConf and replaced linked map / set with normal.

Result:

Correct behaviour.