### PR TITLE
Update FSTConfiguration.java

### DIFF
--- a/src/main/java/org/nustaq/serialization/FSTConfiguration.java
+++ b/src/main/java/org/nustaq/serialization/FSTConfiguration.java
@@ -1123,12 +1123,7 @@ public class FSTConfiguration {
         try {
             return getObjectInput(b).readObject();
         } catch (Exception e) {
-            System.out.println("unable to decode:" +new String(b,0,0,Math.max(b.length,100)) );
-            try {
-                getObjectInput(b).readObject();
-            } catch (Exception e1) {
-                // debug hook
-            }
+            System.out.println("unable to decode:" +new String(b,0,0,Math.min(b.length,100)) );
             FSTUtil.<RuntimeException>rethrow(e);
         }
         return null;


### PR DESCRIPTION
The method asObject() could lead to an IndexOutOfBoundException if the byte array argument was less than 100 bytes. 