### PR TITLE
Issue #147: adding dynamic-import-packages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,7 @@
                         <Bundle-Version>${project.version}</Bundle-Version>
                         <Import-Package>*</Import-Package>
                         <Export-Package>org.nustaq.*;-noimport:=true</Export-Package>
+                        <DynamicImport-Package>*</DynamicImport-Package>
                     </instructions>
                 </configuration>
             </plugin>


### PR DESCRIPTION
CLOSES #147

If you use FST in an OGSi environment and want to serialize non JDK
classes, the FST bundle will not able to load the classes. Thus adding
the "dynamic-import-packages" instruction, so it can load all classes exported by any bundle.