### PR TITLE
remove duplicated code in FSTClazzInfoRegistry

### DIFF
--- a/src/main/java/org/nustaq/serialization/FSTClazzInfoRegistry.java
+++ b/src/main/java/org/nustaq/serialization/FSTClazzInfoRegistry.java
@@ -84,14 +84,7 @@ public class FSTClazzInfoRegistry {
             }
         }
 
-        Class[] classes = cl.getDeclaredClasses();
-        for (int i = 0; i < classes.length; i++) {
-            Class aClass = classes[i];
-            if ( ! aClass.isPrimitive() && ! aClass.isArray() ) {
-                names.add(aClass.getName());
-                addAllReferencedClasses(aClass, names,topLevelDone,filter);
-            }
-        }
+    
 
         Class enclosingClass = cl.getEnclosingClass();
         if ( enclosingClass != null ) {


### PR DESCRIPTION
In the method addAllReferencedClasses, there are twice processes for getDeclaredClasses(), just remove the later.