### PR TITLE
Update to jackson-core 2.8.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
         <dependency>
           <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-core</artifactId>
-          <version>2.8.1</version>
+          <version>2.8.6</version>
         </dependency>
 
         <!-- only required if structs are used -->


### PR DESCRIPTION
Updates `jackson-core` from 2.8.1 to 2.8.6

Among other things, this patches against the security vulnerability in `jackson-core` discussed here: [https://github.com/FasterXML/jackson-core/pull/322](https://github.com/FasterXML/jackson-core/pull/322). 

I don't think `fast-serialization` was directly vulnerable from the attack above, but this should appease automatic vulnerability scanners in dependant projects using maven,