### PR TITLE
Support for serializers for interfaces.

### DIFF
--- a/src/main/java/org/nustaq/serialization/FSTClazzLineageInfo.java
+++ b/src/main/java/org/nustaq/serialization/FSTClazzLineageInfo.java
@@ -1,0 +1,102 @@
+package org.nustaq.serialization;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Represents a ordered class lineage based on the specificity of classes, where specificity is defined as follows:
+ * <nl>
+ * <li>null has specificity 0</li>
+ * <li>java.lang.Object has specificity 0</li>
+ * <li>an interface without any extends clause has specificity 1</li>
+ * <li>a class or interface has a lineageInfos of 1 + the specificity of the superclass + the sum of the specificity of the implemented interfaces.</li>
+ * </nl>
+ * @author Odd Moeller 2017-03-08.
+ */
+public final class FSTClazzLineageInfo {
+  private static final Class<?>[] EMPTY_CLASS_ARRAY = new Class<?>[0];
+  private static final LineageInfo OBJECT_LINEAGE_INFO = new LineageInfo(new LinkedHashSet<Class<?>>(Collections.singletonList(Object.class)), 0);
+  private static final ConcurrentMap<Class<?>, LineageInfo> lineageInfos = new ConcurrentHashMap<Class<?>, LineageInfo>();
+  public static final Comparator<Class> SPECIFICITY_CLASS_COMPARATOR = new Comparator<Class>() {
+    @Override
+    public int compare(final Class c1, final Class c2) {
+      return getLineageInfo(c2).specificity - getLineageInfo(c1).specificity;
+    }
+  };
+
+  private FSTClazzLineageInfo() {}
+
+  /**
+   * Returns the specificity of the specified class as defined above.
+   */
+  public static int getSpecificity(final Class<?> clazz) {
+    if (clazz == null) return 0;
+    final LineageInfo lineageInfo = FSTClazzLineageInfo.getLineageInfo(clazz);
+    return lineageInfo == null ? 0 : lineageInfo.specificity;
+  }
+
+  /**
+   * Returns the lineage of the specified class ordered by specificity (the class itself is at position 0 since it is most specific in its lineage).
+   */
+  public static Class<?>[] getLineage(final Class<?> clazz) {
+    final LineageInfo lineageInfo = getLineageInfo(clazz);
+    return lineageInfo == null ? EMPTY_CLASS_ARRAY : lineageInfo.lineage.toArray(new Class<?>[lineageInfo.lineage.size()]);
+  }
+
+  private static LineageInfo getLineageInfo(final Class<?> clazz) {
+    if (clazz == null) return null;
+    else if (clazz.equals(Object.class)) return OBJECT_LINEAGE_INFO;
+    final LineageInfo lineageInfo = lineageInfos.get(clazz);
+    if (lineageInfo != null) {
+      return lineageInfo;
+    }
+
+    int specificity = 1;
+    final LinkedHashSet<Class<?>> ancestors = new LinkedHashSet<Class<?>>();
+    final Class<?> sc = getSuperclass(clazz);
+    final LineageInfo sl = getLineageInfo(sc);
+    if (sl != null) {
+      ancestors.addAll(sl.lineage);
+      specificity += sl.specificity;
+    }
+    for (final Class<?> i : getInterfaces(clazz)) {
+      final LineageInfo il = getLineageInfo(i);
+      if (il != null) {
+        ancestors.removeAll(il.lineage);
+        ancestors.addAll(il.lineage);
+        specificity += il.specificity;
+      }
+    }
+    final Class<?>[] array = ancestors.toArray(new Class<?>[ancestors.size()]);
+    Arrays.sort(array, SPECIFICITY_CLASS_COMPARATOR);
+    final LinkedHashSet<Class<?>> lineage = new LinkedHashSet<Class<?>>(array.length + 1);
+    lineage.add(clazz);
+    Collections.addAll(lineage, array);
+    final LineageInfo result = new LineageInfo(lineage, specificity);
+    lineageInfos.putIfAbsent(clazz, result);
+    return result;
+  }
+
+  private static Class<?> getSuperclass(final Class<?> c) {
+    if (c == null) return null;
+    return c.getSuperclass();
+  }
+
+  private static Class<?>[] getInterfaces(final Class<?> c) {
+    if (c == null) return null;
+    return c.getInterfaces();
+  }
+
+  private static final class LineageInfo {
+    private final LinkedHashSet<Class<?>> lineage;
+    private final int specificity;
+    private LineageInfo(final LinkedHashSet<Class<?>> lineage, final int specificity) {
+      this.lineage = lineage;
+      this.specificity = specificity;
+    }
+  }
+}

--- a/src/main/java/org/nustaq/serialization/FSTClazzLineageInfo.java
+++ b/src/main/java/org/nustaq/serialization/FSTClazzLineageInfo.java
@@ -13,7 +13,7 @@ import java.util.concurrent.ConcurrentMap;
  * <li>null has specificity 0</li>
  * <li>java.lang.Object has specificity 0</li>
  * <li>an interface without any extends clause has specificity 1</li>
- * <li>a class or interface has a lineageInfos of 1 + the specificity of the superclass + the sum of the specificity of the implemented interfaces.</li>
+ * <li>a class or interface has a specificity of 1 + the specificity of the superclass + the sum of the specificity of the implemented interfaces.</li>
  * </nl>
  * @author Odd Moeller 2017-03-08.
  */

--- a/src/main/java/org/nustaq/serialization/FSTSerializerRegistry.java
+++ b/src/main/java/org/nustaq/serialization/FSTSerializerRegistry.java
@@ -28,7 +28,6 @@ import java.util.*;
  *
  */
 public class FSTSerializerRegistry {
-
     private FSTSerializerRegistryDelegate delegate;
 
     public static FSTObjectSerializer NULL = new NULLSerializer();
@@ -94,7 +93,12 @@ public class FSTSerializerRegistry {
                 return ser;
             }
         }
-        return getSerializer(cl,cl);
+        final Class[] lineage = FSTClazzLineageInfo.getLineage(cl);
+        for (final Class ascendant : lineage) {
+            final FSTObjectSerializer serializer = getSerializer(ascendant, cl);
+            if (serializer != null) return serializer;
+        }
+        return null;
     }
 
     final FSTObjectSerializer getSerializer(Class cl, Class lookupStart) {
@@ -111,15 +115,10 @@ public class FSTSerializerRegistry {
                 return serEntry.ser;
             }
         }
-        if ( cl != Object.class && cl != null ) {
-            return getSerializer(cl.getSuperclass(),lookupStart);
-        }
         return null;
     }
 
     public void putSerializer( Class cl, FSTObjectSerializer ser, boolean includeSubclasses) {
         map.put(cl,new SerEntry(includeSubclasses,ser));
     }
-
-
 }

--- a/src/test/ser/LineageTest.java
+++ b/src/test/ser/LineageTest.java
@@ -1,0 +1,64 @@
+package ser;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.nustaq.serialization.FSTClazzLineageInfo.*;
+
+/**
+ * Created by odd on 2017-03-09.
+ */
+public class LineageTest {
+  public static class O {}
+  public static class OO extends O {}
+  public interface I {}
+  public interface II extends I {}
+  public static class OIO extends O implements I {}
+  public static class OIOO extends OIO {}
+  public static class OIOOIO extends OIOO implements I {}
+  public static class OIOIIO extends OIO implements II {}
+  public static class OIOOIIO extends OIOO implements II {}
+
+  @Test
+  public void testSpecificity() {
+    assertSpecificity(null, 0);
+    assertSpecificity(Object.class, 0);
+    assertSpecificity(Serializable.class, 1);
+    assertSpecificity(String.class, 4);
+    assertSpecificity(O.class, 1);
+    assertSpecificity(OO.class, 2);
+    assertSpecificity(I.class, 1);
+    assertSpecificity(II.class, 2);
+    assertSpecificity(OIO.class, 3);
+    assertSpecificity(OIOO.class, 4);
+    assertSpecificity(OIOOIO.class, 6);
+    assertSpecificity(OIOIIO.class, 6);
+    assertSpecificity(OIOOIIO.class, 7);
+  }
+
+  @Test
+  public void testLineage() {
+    assertLineage(null);
+    assertLineage(Object.class, Object.class);
+    assertLineage(Serializable.class, Serializable.class);
+    assertLineage(String.class, String.class, Serializable.class, Comparable.class, CharSequence.class, Object.class);
+    assertLineage(O.class, O.class, Object.class);
+    assertLineage(OO.class, OO.class, O.class, Object.class);
+    assertLineage(I.class, I.class);
+    assertLineage(II.class, II.class, I.class);
+    assertLineage(OIO.class, OIO.class, O.class, I.class, Object.class);
+    assertLineage(OIOO.class, OIOO.class, OIO.class, O.class, I.class, Object.class);
+    assertLineage(OIOOIO.class, OIOOIO.class, OIOO.class, OIO.class, O.class, I.class, Object.class);
+    assertLineage(OIOIIO.class, OIOIIO.class, OIO.class, II.class, O.class, I.class, Object.class);
+    assertLineage(OIOOIIO.class, OIOOIIO.class, OIOO.class, OIO.class, II.class, O.class, I.class, Object.class);
+  }
+
+  private void assertSpecificity(final Class<?> clazz, final int expected) {
+    assertEquals(clazz != null ? clazz.getSimpleName() : "null" + " is " + expected, expected, getSpecificity(clazz));
+  }
+  private void assertLineage(final Class<?> clazz, final Class<?>... expected) {
+    assertArrayEquals(clazz != null ? clazz.getSimpleName() : "null" + " is " + Arrays.toString(expected), expected, getLineage(clazz));
+  }
+}


### PR DESCRIPTION
Adds the ability to register serializers for interfaces (in addition to classes).
To find the most specific serializer for a class C all ascendants of C (both 
superclasses and interfaces) are searched in order of their specificity (i.e. 
a more specific ancestor is checked before a less specific one). The specificity of
a class is defined as follows:
1. null has specificity 0
2. java.lang.Object has specificity 0
3. an interface without any extends clause has specificity 1
4. a class or interface has a specificity of:
   1 + the specificity of the superclass  + the sum of the specificity of the implemented interfaces.