### PR TITLE
Fix #195: Added FSTLogger shim to delegate to logging frameworks

### DIFF
--- a/src/main/java/org/nustaq/logging/FSTLogger.java
+++ b/src/main/java/org/nustaq/logging/FSTLogger.java
@@ -1,0 +1,42 @@
+package org.nustaq.logging;
+
+public final class FSTLogger {
+
+    private static Log binding;
+
+    /**
+     * Initialize FST logging with a {@link Log} binding.
+     * @param log
+     */
+    public static void setBinding(Log log) {
+        binding = log;
+    }
+
+    public static FSTLogger getLogger(Class<?> clazz) {
+        return new FSTLogger(clazz.getName());
+    }
+
+    private final String loggerName;
+    private FSTLogger(String loggerName) {
+        this.loggerName = loggerName;
+    }
+
+    public void log(Level level, String message, /* nullable */ Throwable ex) {
+        if (binding != null) {
+            binding.log(loggerName, level, message, ex);
+        }
+    }
+
+    public enum Level {
+        TRACE,
+        DEBUG,
+        INFO,
+        WARN,
+        ERROR
+    }
+
+    public interface Log {
+
+        void log(String name, Level level, String message, /* nullable */ Throwable ex);
+    }
+}

--- a/src/main/java/org/nustaq/serialization/FSTObjectOutput.java
+++ b/src/main/java/org/nustaq/serialization/FSTObjectOutput.java
@@ -15,6 +15,7 @@
  */
 package org.nustaq.serialization;
 
+import org.nustaq.logging.FSTLogger;
 import org.nustaq.serialization.util.FSTUtil;
 
 import java.io.*;
@@ -35,6 +36,7 @@ import java.util.*;
  */
 public class FSTObjectOutput implements ObjectOutput {
 
+    private static final FSTLogger LOGGER = FSTLogger.getLogger(FSTObjectOutput.class);
     public static Object NULL_PLACEHOLDER = new Object() { public String toString() { return "NULL_PLACEHOLDER"; }};
     public static final byte SPECIAL_COMPATIBILITY_OBJECT_TAG = -19; // see issue 52
     public static final byte ONE_OF = -18;
@@ -880,7 +882,7 @@ public class FSTObjectOutput implements ObjectOutput {
                 FSTClazzInfo newInfo = clinfo;
                 Object replObj = toWrite;
                 if ( newInfo.getWriteReplaceMethod() != null ) {
-                    System.out.println("WARNING: WRITE REPLACE NOT FULLY SUPPORTED");
+                    LOGGER.log(FSTLogger.Level.WARN, "WRITE REPLACE NOT FULLY SUPPORTED", null);
                     try {
                         Object replaced = newInfo.getWriteReplaceMethod().invoke(replObj);
                         if ( replaced != null && replaced != toWrite ) {

--- a/src/main/java/org/nustaq/serialization/coders/FSTStreamDecoder.java
+++ b/src/main/java/org/nustaq/serialization/coders/FSTStreamDecoder.java
@@ -15,6 +15,7 @@
  */
 package org.nustaq.serialization.coders;
 
+import org.nustaq.logging.FSTLogger;
 import org.nustaq.serialization.FSTClazzInfo;
 import org.nustaq.serialization.FSTClazzNameRegistry;
 import org.nustaq.serialization.FSTConfiguration;
@@ -29,6 +30,7 @@ import java.io.InputStream;
  * Default Coder used for serialization. Decodes a binary stream written with FSTStreamEncoder
  */
 public class FSTStreamDecoder implements FSTDecoder {
+    private static final FSTLogger LOGGER = FSTLogger.getLogger(FSTStreamDecoder.class);
 
     private FSTInputStream input;
     byte ascStringCache[];
@@ -175,6 +177,7 @@ public class FSTStreamDecoder implements FSTDecoder {
                 throw new RuntimeException("unexpected primitive type " + componentType.getName());
             }
         } catch (IOException e) {
+            LOGGER.log(FSTLogger.Level.ERROR, "Failed to read primitive array", e);
             FSTUtil.<RuntimeException>rethrow(e);
         }
         return null;

--- a/src/main/java/org/nustaq/serialization/util/FSTInputStream.java
+++ b/src/main/java/org/nustaq/serialization/util/FSTInputStream.java
@@ -15,6 +15,8 @@
  */
 package org.nustaq.serialization.util;
 
+import org.nustaq.logging.FSTLogger;
+
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -26,6 +28,8 @@ import java.io.InputStream;
  * To change this template use File | Settings | File Templates.
  */
 public final class FSTInputStream extends InputStream {
+
+    private static final FSTLogger LOGGER = FSTLogger.getLogger(FSTInputStream.class);
 
     public int chunk_size = 8000;
     public static ThreadLocal<byte[]> cachedBuffer = new ThreadLocal<byte[]>();
@@ -81,6 +85,7 @@ public final class FSTInputStream extends InputStream {
                 fullyRead = true;
             }
         } catch (Exception iex) {
+            LOGGER.log(FSTLogger.Level.ERROR, "Failed to read next chunk, assuming fully read", iex);
             fullyRead = true;
         }
     }

--- a/src/main/java/org/nustaq/serialization/util/FSTOutputStream.java
+++ b/src/main/java/org/nustaq/serialization/util/FSTOutputStream.java
@@ -16,6 +16,8 @@
 
 package org.nustaq.serialization.util;
 
+import org.nustaq.logging.FSTLogger;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Arrays;
@@ -28,6 +30,8 @@ import java.util.Arrays;
  * To change this template use File | Settings | File Templates.
  */
 public final class FSTOutputStream extends OutputStream {
+
+    private static final FSTLogger LOGGER = FSTLogger.getLogger(FSTOutputStream.class);
 
     /**
      * The buffer where data is stored.
@@ -91,7 +95,7 @@ public final class FSTOutputStream extends OutputStream {
         try {
             buf = Arrays.copyOf(buf, newCapacity);
         } catch (OutOfMemoryError ome) {
-            System.out.println("OME resize from " + buf.length + " to " + newCapacity + " clearing caches ..");
+            LOGGER.log(FSTLogger.Level.ERROR, "OME resize from " + buf.length + " to " + newCapacity + " clearing caches ..", ome);
             throw new RuntimeException(ome);
         }
     }


### PR DESCRIPTION
This allows FST to log to other logging frameworks (or none at
all).
This change does not include any implementations, it may make
sense to add a stdout/stderr binding in test sources.