### PR TITLE
When InputStream reads fail, propagate the exception

### DIFF
--- a/src/main/java/org/nustaq/serialization/util/FSTInputStream.java
+++ b/src/main/java/org/nustaq/serialization/util/FSTInputStream.java
@@ -84,9 +84,9 @@ public final class FSTInputStream extends InputStream {
             } else {
                 fullyRead = true;
             }
-        } catch (Exception iex) {
-            LOGGER.log(FSTLogger.Level.ERROR, "Failed to read next chunk, assuming fully read", iex);
-            fullyRead = true;
+        } catch (IOException e) {
+            LOGGER.log(FSTLogger.Level.ERROR, "Failed to read next chunk from InputStream", e);
+            throw new RuntimeException("Failed to read next chunk from InputStream", e);
         }
     }
 


### PR DESCRIPTION
FSTInputStream.readNextChunk throws on failure rather than
silently assuming the stream has completed.

In situations where it's necessary to power through failing
streams, a wrapped stream can be provided which reads until an
exception is thrown, then reports that it is finished.