### PR TITLE
Avoid re-reading data from a cached buffer

### DIFF
--- a/src/main/java/org/nustaq/serialization/coders/FSTStreamDecoder.java
+++ b/src/main/java/org/nustaq/serialization/coders/FSTStreamDecoder.java
@@ -290,6 +290,9 @@ public class FSTStreamDecoder implements FSTDecoder {
     @Override
     public final byte readFByte() throws IOException {
         input.ensureReadAhead(1);
+        if (input.pos > input.count) {
+            throw new IOException("Failed to read the next byte");
+        }
         return input.buf[input.pos++];
     }
 

--- a/src/test/ser/BasicReuseTest.java
+++ b/src/test/ser/BasicReuseTest.java
@@ -1,0 +1,42 @@
+package ser;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.nustaq.serialization.FSTConfiguration;
+import org.nustaq.serialization.FSTObjectInput;
+import org.nustaq.serialization.FSTObjectOutput;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+public class BasicReuseTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void testStreamReuse() throws Exception {
+        FSTConfiguration configuration = FSTConfiguration.createDefaultConfiguration();
+
+        String expected = "Hello, World!";
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        FSTObjectOutput fstObjectOutput = configuration.getObjectOutput(baos);
+        try {
+            fstObjectOutput.writeObject(expected);
+        } finally {
+            fstObjectOutput.flush();
+        }
+        byte[] serializedData = baos.toByteArray();
+        FSTObjectInput input = configuration.getObjectInput(new ByteArrayInputStream(serializedData));
+        Object read = input.readObject();
+        Assert.assertEquals(expected, read);
+
+        FSTObjectInput secondInput = configuration.getObjectInput(new ByteArrayInputStream(new byte[0]));
+        expectedException.expect(IOException.class);
+        expectedException.expectMessage("Failed to read");
+        secondInput.readObject();
+    }
+}


### PR DESCRIPTION
Attempting to read an empty stream previously resulted in
readObject returning the last object the FSTObjectInput read.

This bug still exists in the minbin decoder.