### PR TITLE
Fix getCLInfo thread safety where null class prematurely unlocks

### DIFF
--- a/src/main/java/org/nustaq/serialization/FSTClazzInfoRegistry.java
+++ b/src/main/java/org/nustaq/serialization/FSTClazzInfoRegistry.java
@@ -120,7 +120,6 @@ public class FSTClazzInfoRegistry {
             FSTClazzInfo res = (FSTClazzInfo) mInfos.get(c);
             if (res == null) {
                 if (c == null) {
-                    rwLock.set(false);
                     throw new NullPointerException("Class is null");
                 }
                 if ( conf.getVerifier() != null ) {


### PR DESCRIPTION
In this scenario, the finally block can unlock rwLock that has
already been acquired by another invocation.