### PR TITLE
Fix FSTInputStream reading old data from the buffer

### DIFF
--- a/src/main/java/org/nustaq/serialization/FSTDecoder.java
+++ b/src/main/java/org/nustaq/serialization/FSTDecoder.java
@@ -26,7 +26,7 @@ public interface FSTDecoder {
     void setConf( FSTConfiguration conf );
     String readStringUTF() throws IOException;
     String readStringAsc() throws IOException;
-    Object readFPrimitiveArray(Object array, Class componentType, int len);
+    Object readFPrimitiveArray(Object array, Class componentType, int len) throws IOException;
     void readFIntArr(int len, int[] arr) throws IOException;
     int readFInt() throws IOException;
     double readFDouble() throws IOException;
@@ -42,7 +42,16 @@ public interface FSTDecoder {
     int getInputPos();
     void moveTo(int position);
     void setInputStream(InputStream in);
-    int ensureReadAhead(int bytes); // might signal eof by returning -1, depends on decoder impl though
+    int ensureReadAhead(int bytes) throws IOException; // might signal eof by returning -1, depends on decoder impl though
+
+    /**
+     * Similar to {@link #ensureReadAhead(int)}, except this provides no guarantees that any
+     * data is actually read. This method serves to prebuffer data if possible for performance,
+     * but should not be necessary for correctness.
+     *
+     * @param bytes maximum number of bytes to read ahead, if possible
+     */
+    void attemptReadAhead(int bytes);
 
     void reset();
     void resetToCopyOf(byte[] bytes, int off, int len);
@@ -56,7 +65,7 @@ public interface FSTDecoder {
     void close();
 
     void skip(int n);
-    void readPlainBytes(byte[] b, int off, int len);
+    void readPlainBytes(byte[] b, int off, int len) throws IOException;
 
     byte readObjectHeaderTag() throws IOException;
     int getObjectHeaderLen(); // len field of last header read (if avaiable)

--- a/src/main/java/org/nustaq/serialization/FSTObjectInput.java
+++ b/src/main/java/org/nustaq/serialization/FSTObjectInput.java
@@ -544,7 +544,7 @@ public class FSTObjectInput implements ObjectInput {
         if ( clzSerInfo.isExternalizable() )
         {
             int tmp = readPos;
-            getCodec().ensureReadAhead(readExternalReadAHead);
+            getCodec().attemptReadAhead(readExternalReadAHead);
             ((Externalizable)newObj).readExternal(this);
             getCodec().readExternalEnd();
             if ( clzSerInfo.getReadResolveMethod() != null ) {

--- a/src/main/java/org/nustaq/serialization/FSTObjectInputNoShared.java
+++ b/src/main/java/org/nustaq/serialization/FSTObjectInputNoShared.java
@@ -86,7 +86,7 @@ public class FSTObjectInputNoShared extends FSTObjectInput {
         }
         if ( clzSerInfo.isExternalizable() )
         {
-            getCodec().ensureReadAhead(readExternalReadAHead);
+            getCodec().attemptReadAhead(readExternalReadAHead);
             ((Externalizable)newObj).readExternal(this);
             getCodec().readExternalEnd();
         } else {

--- a/src/main/java/org/nustaq/serialization/coders/FSTJsonDecoder.java
+++ b/src/main/java/org/nustaq/serialization/coders/FSTJsonDecoder.java
@@ -1,7 +1,15 @@
 package org.nustaq.serialization.coders;
 
-import com.fasterxml.jackson.core.*;
-import org.nustaq.serialization.*;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonLocation;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.JsonTokenId;
+import org.nustaq.serialization.FSTClazzInfo;
+import org.nustaq.serialization.FSTConfiguration;
+import org.nustaq.serialization.FSTDecoder;
+import org.nustaq.serialization.FSTObjectInput;
+import org.nustaq.serialization.FSTObjectOutput;
 import org.nustaq.serialization.util.FSTInputStream;
 import org.nustaq.serialization.util.FSTUtil;
 
@@ -229,6 +237,10 @@ public class FSTJsonDecoder implements FSTDecoder {
     @Override
     public int ensureReadAhead(int bytes) {
         return 0;
+    }
+
+    @Override
+    public void attemptReadAhead(int bytes) {
     }
 
     @Override
@@ -658,7 +670,7 @@ public class FSTJsonDecoder implements FSTDecoder {
 
     @Override
     public int available() {
-        fstInput.ensureReadAhead(1);
+        fstInput.attemptReadAhead(1);
         return fstInput.available();
     }
 

--- a/src/main/java/org/nustaq/serialization/coders/FSTMinBinDecoder.java
+++ b/src/main/java/org/nustaq/serialization/coders/FSTMinBinDecoder.java
@@ -216,6 +216,10 @@ public class FSTMinBinDecoder implements FSTDecoder {
     }
 
     @Override
+    public void attemptReadAhead(int bytes) {
+    }
+
+    @Override
     public void reset() {
         input.reset();
     }

--- a/src/test/ser/BasicReuseTest.java
+++ b/src/test/ser/BasicReuseTest.java
@@ -36,7 +36,7 @@ public class BasicReuseTest {
 
         FSTObjectInput secondInput = configuration.getObjectInput(new ByteArrayInputStream(new byte[0]));
         expectedException.expect(IOException.class);
-        expectedException.expectMessage("Failed to read");
+        expectedException.expectMessage("Only read");
         secondInput.readObject();
     }
 }


### PR DESCRIPTION
ensureReadAhead previously did not error when it read fewer than the
requested number of bytes.

Added new FSTDecoder.attemptReadAhead(int byte) method to prebuffer
if possible, where ensureReadAhead will throw if the requested
number of bytes cannot be read.