### PR TITLE
implementation for fields compatibility in default configuration

### DIFF
--- a/src/main/java/org/nustaq/serialization/FSTClazzInfoRegistry.java
+++ b/src/main/java/org/nustaq/serialization/FSTClazzInfoRegistry.java
@@ -115,6 +115,10 @@ public class FSTClazzInfoRegistry {
     }
 
     public FSTClazzInfo getCLInfo(Class c, FSTConfiguration conf) {
+    	return getCLInfo(c, conf, null);
+    }
+    
+    public FSTClazzInfo getCLInfo(Class c, FSTConfiguration conf, long[] fieldsUniqueId) {
         while(!rwLock.compareAndSet(false,true));
         try {
             FSTClazzInfo res = (FSTClazzInfo) mInfos.get(c);
@@ -126,7 +130,7 @@ public class FSTClazzInfoRegistry {
                     if ( ! conf.getVerifier().allowClassDeserialization(c) )
                         throw new RuntimeException("tried to deserialize forbidden class "+c.getName() );
                 }
-                res = new FSTClazzInfo(conf, c, this, ignoreAnnotations);
+                res = new FSTClazzInfo(conf, c, this, ignoreAnnotations, fieldsUniqueId);
                 mInfos.put(c, res);
             }
             return res;

--- a/src/main/java/org/nustaq/serialization/FSTConfiguration.java
+++ b/src/main/java/org/nustaq/serialization/FSTConfiguration.java
@@ -57,6 +57,36 @@ import java.util.concurrent.atomic.AtomicBoolean;
  *
  */
 public class FSTConfiguration {
+	
+	/**
+	 * ARC: a very simple hack in order to handle deserialisation of un-synched classes from the point of view of fields.
+	 * 
+	 * The hack is handling removed/added fields on the receiver side or sending side. EQ: a field is removed/added at the 
+	 * serialisation VM or de-serialising VM.
+	 * 
+	 * The hack is using an uniqueId computed as a CRC32 on the name of the declaring class and the field name. The uniqueId
+	 * is used to find the removed or added fields. 
+	 * 
+	 * On the de-serialising side the removed fields are read but not set, the new fields are ignored. In order to "jump" over
+	 * the field data we will prefix the data with a byte or 4byte information about the size of the serialized field.    
+	 * 
+	 * The hack is enforcing the order of de-serialisation as the one at the time of serialisation. 
+	 * 
+	 * Note: I did not implemented all the scenarios as we do not need it them.
+	 * 
+	 * Thus the hack is working only with in default SHARED configuration with classes that are not registred and that are not in 
+	 * compatible mode! Also the hack is not working with Conditional or Version annotations
+	 * 
+	 * Further work : make this configurable and not static as it is
+	 * Cons: the resulting binary format is bigger.
+	 * Pros: backward/forward compatibility between versions of classes in simple cases (adding/removing fields)
+	 */
+	public final static boolean FIELDS_FIX = true; 
+	public final static boolean FIELDS_FIX_LENGTH = FIELDS_FIX;
+	/**
+	 * ARC: store enum with names and not ordinal - as if the position changes then the deserialisation is not good. 
+	 */
+	public static boolean FIELDS_FIX_ENUM_WITH_NAME = FIELDS_FIX;
 
     static enum ConfType {
         DEFAULT, UNSAFE, MINBIN, JSON, JSONPRETTY

--- a/src/main/java/org/nustaq/serialization/FSTEncoder.java
+++ b/src/main/java/org/nustaq/serialization/FSTEncoder.java
@@ -66,6 +66,12 @@ public interface FSTEncoder {
      * @param v
      */
     void writeInt32At(int position, int v);
+    /**
+     * used to write uncompressed int (guaranteed length = 1) at a (eventually recent) position
+     * @param position
+     * @param v
+     */
+    void writeByteAt(int position, byte v);
 
     /**
      * if output stream is null, just encode into a byte array

--- a/src/main/java/org/nustaq/serialization/coders/FSTBytezEncoder.java
+++ b/src/main/java/org/nustaq/serialization/coders/FSTBytezEncoder.java
@@ -263,6 +263,15 @@ public class FSTBytezEncoder implements FSTEncoder {
         }
         buffout.putInt(position,v);
     }
+    @Override
+    public void writeByteAt(int position, byte v) {
+        try {
+            ensureFree( position+1);
+        } catch (IOException e) {
+            FSTUtil.<RuntimeException>rethrow(e);
+        }
+        buffout.put(position,v);
+    }
 
     /**
      * if output stream is null, just encode into a byte array

--- a/src/main/java/org/nustaq/serialization/coders/FSTJsonEncoder.java
+++ b/src/main/java/org/nustaq/serialization/coders/FSTJsonEncoder.java
@@ -176,6 +176,10 @@ public class FSTJsonEncoder implements FSTEncoder {
     public void writeInt32At(int position, int v) {
         throw new RuntimeException("not supported");
     }
+    @Override
+    public void writeByteAt(int position, byte v) {
+        throw new RuntimeException("not supported");
+    }
 
     @Override
     public void setOutstream(OutputStream outstream) {

--- a/src/main/java/org/nustaq/serialization/coders/FSTMinBinEncoder.java
+++ b/src/main/java/org/nustaq/serialization/coders/FSTMinBinEncoder.java
@@ -157,6 +157,10 @@ public class FSTMinBinEncoder implements FSTEncoder {
     public void writeInt32At(int position, int v) {
         throw new RuntimeException("not supported");
     }
+    @Override
+    public void writeByteAt(int position, byte v) {
+        throw new RuntimeException("not supported");
+    }
 
     /**
      * if output stream is null, just encode into a byte array

--- a/src/main/java/org/nustaq/serialization/coders/FSTStreamEncoder.java
+++ b/src/main/java/org/nustaq/serialization/coders/FSTStreamEncoder.java
@@ -499,6 +499,10 @@ public class FSTStreamEncoder implements FSTEncoder {
         buffout.buf[position+2] = (byte) (v >>> 16);
         buffout.buf[position+3] = (byte) (v >>> 24);
     }
+    @Override
+    public void writeByteAt(int position, byte v) {
+        buffout.buf[position] = v;
+    }
 
     /**
      * if output stream is null, just encode into a byte array 


### PR DESCRIPTION
a very simple hack in order to handle deserialisation of un-synched classes from the point of view of fields.

The hack is handling removed/added fields on the receiver side or sending side. EQ: a field is removed/added at the 
serialisation VM or de-serialising VM.

The hack is using an uniqueId computed as a CRC32 on the name of the declaring class and the field name. The uniqueId
is used to find the removed or added fields. 

On the de-serialising side the removed fields are read but not set, the new fields are ignored. In order to "jump" over
the field data we will prefix the data with a byte or 4byte information about the size of the serialized field.    

The hack is enforcing the order of de-serialisation as the one at the time of serialisation. 

Note: I did not implemented all the scenarios as we do not need it them.

Thus the hack is working only with in default SHARED configuration with classes that are not registred and that are not in 
compatible mode! Also the hack is not working with Conditional or Version annotations

Further work : make this configurable and not static as it is
Cons: the resulting binary format is bigger.
Pros: backward/forward compatibility between versions of classes in simple cases (adding/removing fields)
