### PR TITLE
Remove old version of java-util

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,13 +161,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.cedarsoftware</groupId>
-            <artifactId>java-util</artifactId>
-            <version>1.4.0</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.8.1</version>


### PR DESCRIPTION
There are two dependencies of java-util in pom.xml - 1.9.0 and 1.4.0. Remove older one.