### PR TITLE
Fixes #235 : concurrency bug in FSTStreamDecoder/FSTStreamEncoder

### DIFF
--- a/src/main/java/org/nustaq/serialization/coders/FSTStreamDecoder.java
+++ b/src/main/java/org/nustaq/serialization/coders/FSTStreamDecoder.java
@@ -39,23 +39,13 @@ public class FSTStreamDecoder implements FSTDecoder {
 
     public FSTStreamDecoder(FSTConfiguration conf) {
         this.conf = conf;
-        clnames = (FSTClazzNameRegistry) conf.getCachedObject(FSTClazzNameRegistry.class);
-        if (clnames == null) {
-            clnames = new FSTClazzNameRegistry(conf.getClassRegistry());
-        } else {
-            clnames.clear();
-        }
+        clnames = new FSTClazzNameRegistry(conf.getClassRegistry());
     }
 
     @Override
     public void setConf(FSTConfiguration conf) {
         this.conf = conf;
-        clnames = (FSTClazzNameRegistry) conf.getCachedObject(FSTClazzNameRegistry.class);
-        if (clnames == null) {
-            clnames = new FSTClazzNameRegistry(conf.getClassRegistry());
-        } else {
-            clnames.clear();
-        }
+        clnames = new FSTClazzNameRegistry(conf.getClassRegistry());
     }
 
     public int ensureReadAhead(int bytes) {

--- a/src/main/java/org/nustaq/serialization/coders/FSTStreamEncoder.java
+++ b/src/main/java/org/nustaq/serialization/coders/FSTStreamEncoder.java
@@ -35,23 +35,13 @@ public class FSTStreamEncoder implements FSTEncoder {
 
     public FSTStreamEncoder(FSTConfiguration conf) {
         this.conf = conf;
-        clnames = (FSTClazzNameRegistry) conf.getCachedObject(FSTClazzNameRegistry.class);
-        if ( clnames == null ) {
-            clnames = new FSTClazzNameRegistry(conf.getClassRegistry());
-        } else {
-            clnames.clear();
-        }
+        clnames = new FSTClazzNameRegistry(conf.getClassRegistry());
     }
 
     @Override
     public void setConf(FSTConfiguration conf) {
         this.conf = conf;
-        clnames = (FSTClazzNameRegistry) conf.getCachedObject(FSTClazzNameRegistry.class);
-        if ( clnames == null ) {
-            clnames = new FSTClazzNameRegistry(conf.getClassRegistry());
-        } else {
-            clnames.clear();
-        }
+        clnames = new FSTClazzNameRegistry(conf.getClassRegistry());
     }
 
     void writeFBooleanArr(boolean[] arr, int off, int len) throws IOException {


### PR DESCRIPTION
The current implementation of the cache within these classes is not thread safe, as seen by https://github.com/RuedigerMoeller/fast-serialization/issues/235 and the test case I have attached to that issue.

This might potentially have some negative performance implications but overall given the severity of the bug, I believe correctness might be more important.
Proper synchronization or protection against these fields is likely possible but beyond my current understand of the codebase, as the code involved for this is quite complex.