### PR TITLE
Expose getters for some corresponding setters

### DIFF
--- a/src/main/java/org/nustaq/serialization/coders/FSTStreamDecoder.java
+++ b/src/main/java/org/nustaq/serialization/coders/FSTStreamDecoder.java
@@ -452,6 +452,10 @@ public class FSTStreamDecoder implements FSTDecoder {
         clnames.clear();
     }
 
+    public InputStream getInputStream() {
+        return input;
+    }
+
     @Override
     public void resetToCopyOf(byte[] bytes, int off, int len) {
         input.reset();

--- a/src/main/java/org/nustaq/serialization/coders/FSTStreamEncoder.java
+++ b/src/main/java/org/nustaq/serialization/coders/FSTStreamEncoder.java
@@ -526,6 +526,10 @@ public class FSTStreamEncoder implements FSTEncoder {
         else
             buffout.setOutstream(outstream);
     }
+
+    public OutputStream getOutstream() {
+        return buffout;
+    }
     
     /**
      * writes current buffer to underlying output and resets buffer. 


### PR DESCRIPTION
Need to get access to the underlying buffers to reset them when we serialize very large objects with many threads to avoid OOM.