### PR TITLE
Register proxy serializer and support JDK Proxy class name lookup

### DIFF
--- a/src/main/java/org/nustaq/serialization/FSTClazzNameRegistry.java
+++ b/src/main/java/org/nustaq/serialization/FSTClazzNameRegistry.java
@@ -21,6 +21,7 @@ import org.nustaq.serialization.util.FSTObject2IntMap;
 import org.nustaq.serialization.util.FSTUtil;
 
 import java.io.IOException;
+import java.lang.reflect.Proxy;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -183,6 +184,8 @@ public class FSTClazzNameRegistry {
         }
     }
 
+
+    private static final String JDKPROXYCLASSPREFIX = "com.sun.proxy.$Proxy"; // Might only work with Oracle JDK
     HashMap<String,Class> classCache = new HashMap<String, Class>(200);
     AtomicBoolean classCacheLock = new AtomicBoolean(false);
     public Class classForName(String clName, FSTConfiguration conf) throws ClassNotFoundException {
@@ -226,7 +229,10 @@ public class FSTClazzNameRegistry {
                             }
                         }
                         return actorClz;
-                    } else {
+                    } else if (clName.startsWith(JDKPROXYCLASSPREFIX)) {
+                        res = Proxy.class;
+                    }
+                    else {
                         if ( conf.getLastResortResolver() != null ) {
                             Class aClass = conf.getLastResortResolver().getClass(clName);
                             if ( aClass != null )

--- a/src/main/java/org/nustaq/serialization/FSTConfiguration.java
+++ b/src/main/java/org/nustaq/serialization/FSTConfiguration.java
@@ -35,6 +35,7 @@ import org.objenesis.ObjenesisStd;
 
 import java.io.*;
 import java.lang.ref.SoftReference;
+import java.lang.reflect.Proxy;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.URL;
@@ -502,6 +503,7 @@ public class FSTConfiguration {
         reg.putSerializer(ConcurrentHashMap.class, new FSTMapSerializer(), true);
         reg.putSerializer(FSTStruct.class, new FSTStructSerializer(), true);
         reg.putSerializer(Throwable.class, new FSTThrowableSerializer(),true);
+        reg.putSerializer(Proxy.class, new FSTProxySerializer(),true);
 
         reg.putSerializer(BitSet.class, new FSTBitSetSerializer(),true);
         reg.putSerializer(Timestamp.class, new FSTTimestampSerializer(),true);
@@ -837,6 +839,8 @@ public class FSTConfiguration {
         classRegistry.registerClass(BitSet.class,this);
         classRegistry.registerClass(Timestamp.class, this);
         classRegistry.registerClass(Locale.class,this);
+
+        classRegistry.registerClass(Proxy.class,this);
 
         classRegistry.registerClass(StringBuffer.class,this);
         classRegistry.registerClass(StringBuilder.class,this);


### PR DESCRIPTION
This is the second piece that actually uses the Proxy Serialization.  It will likely only work on Oracle JDK but other JDKs can use this with their own last resort class loader