### PR TITLE
Always clearing next map (bug #278)

### DIFF
--- a/src/main/java/org/nustaq/serialization/util/DefaultFSTInt2ObjectMap.java
+++ b/src/main/java/org/nustaq/serialization/util/DefaultFSTInt2ObjectMap.java
@@ -176,9 +176,9 @@ public class DefaultFSTInt2ObjectMap<V> implements FSTInt2ObjectMap <V>{
             FSTUtil.clear(mKeys);
             FSTUtil.clear(mValues);
             mNumberOfElements = 0;
-            if (next != null) {
-                next.clear();
-            }
+        }
+        if (next != null) {
+            next.clear();
         }
     }
 }


### PR DESCRIPTION
This pull request aims to correct bug https://github.com/RuedigerMoeller/fast-serialization/issues/278
When the `clear()` method is called on a `DefaultFSTInt2ObjectMap`, the `next` map is also cleared always now.