### PR TITLE
Fixes bug in serializer resolution

### DIFF
--- a/src/main/java/org/nustaq/serialization/FSTSerializerRegistry.java
+++ b/src/main/java/org/nustaq/serialization/FSTSerializerRegistry.java
@@ -108,11 +108,11 @@ public class FSTSerializerRegistry {
         }
         final SerEntry serEntry = map.get(cl);
         if ( serEntry != null ) {
-            if ( cl == lookupStart && serEntry.ser.willHandleClass(cl)) {
+            if ( cl == lookupStart && serEntry.ser.willHandleClass(lookupStart)) {
                 return serEntry.ser;
             }
-            if ( serEntry.forSubClasses && serEntry.ser.willHandleClass(cl) ) {
-                putSerializer(lookupStart,serEntry.ser, false);
+            if ( serEntry.forSubClasses && serEntry.ser.willHandleClass(lookupStart) ) {
+                putSerializer(lookupStart, serEntry.ser, false);
                 return serEntry.ser;
             }
         }


### PR DESCRIPTION
Passes the original `lookupStart` to the `willHandleClass` method during the class hierarchy traversal in `FSTSerializerRegistry.getSerializer` instead of the current traversal class `cl` (since it is a serializer for the original class that the `getSerializer` method should find).