### PR TITLE
Fix for issues 274 and 235

### DIFF
--- a/src/main/java/org/nustaq/serialization/FSTClazzInfo.java
+++ b/src/main/java/org/nustaq/serialization/FSTClazzInfo.java
@@ -105,7 +105,7 @@ public final class FSTClazzInfo {
     boolean isAsciiNameShortString = false;
     boolean requiresInit = false;
     boolean hasTransient;
-    FSTObjectSerializer ser;
+    volatile FSTObjectSerializer ser;
     FSTFieldInfo fieldInfo[]; // serializable fields
 
     Class clazz;
@@ -975,19 +975,21 @@ public final class FSTClazzInfo {
      * @return
      */
     public FSTObjectSerializer getSer() {
-        if (ser == null) {
+        FSTObjectSerializer serializer = ser;
+        if (serializer == null) {
             if (clazz == null) {
                 return null;
             }
-            ser = getSerNoStore();
-            if (ser == null) {
+            serializer = getSerNoStore();
+            if (serializer == null) {
                 ser = FSTSerializerRegistry.NULL;
+                return null;
             }
-        }
-        if (ser == FSTSerializerRegistry.NULL) {
+            ser = serializer;
+        } else if (serializer == FSTSerializerRegistry.NULL) {
             return null;
         }
-        return ser;
+        return serializer;
     }
 
     // no sideffecting lookup

--- a/src/main/java/org/nustaq/serialization/FSTObjectInput.java
+++ b/src/main/java/org/nustaq/serialization/FSTObjectInput.java
@@ -997,6 +997,7 @@ public class FSTObjectInput implements ObjectInput {
         closed = true;
         resetAndClearRefs();
         conf.returnObject(objects);
+        objects = null;
         getCodec().close();
     }
 

--- a/src/main/java/org/nustaq/serialization/FSTObjectOutput.java
+++ b/src/main/java/org/nustaq/serialization/FSTObjectOutput.java
@@ -164,9 +164,10 @@ public class FSTObjectOutput implements ObjectOutput {
     public void close() throws IOException {
         flush();
         closed = true;
-        getCodec().close();
         resetAndClearRefs();
+        getCodec().close();
         conf.returnObject(objects);
+        objects = null;
     }
 
 

--- a/src/main/java/org/nustaq/serialization/FSTSerializerRegistry.java
+++ b/src/main/java/org/nustaq/serialization/FSTSerializerRegistry.java
@@ -31,7 +31,7 @@ public class FSTSerializerRegistry {
 
     private FSTSerializerRegistryDelegate delegate;
 
-    public static FSTObjectSerializer NULL = new NULLSerializer();
+    public static final FSTObjectSerializer NULL = new NULLSerializer();
 
     public void setDelegate(FSTSerializerRegistryDelegate delegate) {
         this.delegate = delegate;

--- a/src/main/java/org/nustaq/serialization/coders/FSTBytezDecoder.java
+++ b/src/main/java/org/nustaq/serialization/coders/FSTBytezDecoder.java
@@ -387,6 +387,7 @@ public class FSTBytezDecoder  implements FSTDecoder {
     @Override
     public void close() {
         conf.returnObject(clnames);
+        clnames = null;
     }
 
     @Override

--- a/src/main/java/org/nustaq/serialization/coders/FSTBytezEncoder.java
+++ b/src/main/java/org/nustaq/serialization/coders/FSTBytezEncoder.java
@@ -234,6 +234,7 @@ public class FSTBytezEncoder implements FSTEncoder {
     @Override
     public void close() throws IOException {
         conf.returnObject(clnames);
+        clnames = null;
     }
 
     @Override

--- a/src/main/java/org/nustaq/serialization/coders/FSTStreamDecoder.java
+++ b/src/main/java/org/nustaq/serialization/coders/FSTStreamDecoder.java
@@ -493,6 +493,7 @@ public class FSTStreamDecoder implements FSTDecoder {
     @Override
     public void close() {
         conf.returnObject(clnames);
+        clnames = null;
     }
 
     @Override

--- a/src/main/java/org/nustaq/serialization/coders/FSTStreamEncoder.java
+++ b/src/main/java/org/nustaq/serialization/coders/FSTStreamEncoder.java
@@ -475,7 +475,9 @@ public class FSTStreamEncoder implements FSTEncoder {
     @Override
     public void close() throws IOException {
         buffout.close();
+        clnames.clear();
         conf.returnObject(clnames);
+        clnames = null;
     }
 
     @Override


### PR DESCRIPTION
This fixes two bugs caused by race conditions.

The first is in ```FSTClazzInfo.getSer()```, which uses what seems to be a kind of "broken doible-checked locking". When multiple threads are racing in ```getSer()```, sometimes ```FSTSerializerRegistry.NULL``` is returned, with chaos ensuing. An obvious fix would be to make ```FSTClazzInfo.getSer()``` synchronized, but simply making ```ser``` volatile and using a local variable is enough to fix it.

The second is in ```FSTObjectOutput.close()```. Here, the codec is modified after it has been returned to the public configury.
This kind of error is trivially detectable if you null out any references you hold to an object after returning it, so I've done that everywhere. Also, this means that there is less work for the garbage collector to do, and we all should be nice to our garbage collectors.