### PR TITLE
JSON encoding - Enums which override toString

### DIFF
--- a/src/main/java/org/nustaq/serialization/coders/FSTJsonEncoder.java
+++ b/src/main/java/org/nustaq/serialization/coders/FSTJsonEncoder.java
@@ -326,7 +326,7 @@ public class FSTJsonEncoder implements FSTEncoder {
                 gen.writeFieldName(fieldNames.ENUM_S);
                 writeSymbolicClazz(null,c);
                 gen.writeFieldName(fieldNames.VAL_S);
-                gen.writeString(toWrite.toString());
+                gen.writeString(((Enum)toWrite).name());
                 gen.writeEndObject();
                 return true;
             default:


### PR DESCRIPTION
Using toString in the encoder and Enum.valueOf is not reversible if an enum overrides toString. name and valueOf are the correct inverse functions.