### PR TITLE
JSON decoder for Externalizable reads end array

### DIFF
--- a/src/main/java/org/nustaq/serialization/coders/FSTJsonDecoder.java
+++ b/src/main/java/org/nustaq/serialization/coders/FSTJsonDecoder.java
@@ -666,7 +666,7 @@ public class FSTJsonDecoder implements FSTDecoder {
 
     @Override
     public void readExternalEnd() {
-        consumeEndMarker();
+        readArrayEnd(null); // Always added in FSTJsonEncoder for externalisable objects
     }
 
     @Override


### PR DESCRIPTION
- JSON encoding for Externalizable objects always adds an array, into which the Externalizable writes data. This change makes readExternalEnd read this array end, even if consumeEndMarker is not implemented.